### PR TITLE
Add UCSBOrganizationController with GET and POST endpoints and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,68 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBOrganization */
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/UCSBOrganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+  @Autowired UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  /**
+   * This method returns a list of all UCSBOrganizations.
+   *
+   * @return a list of all UCSBOrganizations
+   */
+  @Operation(summary = "List all UCSB Organizations")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBOrganization> allOrganizations() {
+    Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+    return organizations;
+  }
+
+  /**
+   * This method creates a new UCSBOrganization. Accessible only to users with the role
+   * "ROLE_ADMIN".
+   *
+   * @param orgCode the org code of the organization
+   * @param orgTranslationShort short translation of the org name
+   * @param orgTranslation full translation of the org name
+   * @param inactive whether or not the organization is inactive
+   * @return the saved UCSBOrganization
+   */
+  @Operation(summary = "Create a new UCSB Organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBOrganization postOrganization(
+      @Parameter(name = "orgCode") @RequestParam String orgCode,
+      @Parameter(name = "orgTranslationShort") @RequestParam String orgTranslationShort,
+      @Parameter(name = "orgTranslation") @RequestParam String orgTranslation,
+      @Parameter(name = "inactive") @RequestParam boolean inactive) {
+
+    UCSBOrganization organization = new UCSBOrganization();
+    organization.setOrgCode(orgCode);
+    organization.setOrgTranslationShort(orgTranslationShort);
+    organization.setOrgTranslation(orgTranslation);
+    organization.setInactive(inactive);
+
+    UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+    return savedOrganization;
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,166 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBOrganizationRepository ucsbOrganizationRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBOrganization/post")
+                .param("orgCode", "ZPR")
+                .param("orgTranslationShort", "Zeta Phi Rho")
+                .param("orgTranslation", "Zeta Phi Rho Fraternity")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBOrganization/post")
+                .param("orgCode", "ZPR")
+                .param("orgTranslationShort", "Zeta Phi Rho")
+                .param("orgTranslation", "Zeta Phi Rho Fraternity")
+                .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+    UCSBOrganization zpr =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("Zeta Phi Rho")
+            .orgTranslation("Zeta Phi Rho Fraternity")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization sky =
+        UCSBOrganization.builder()
+            .orgCode("SKY")
+            .orgTranslationShort("Skydiving Club")
+            .orgTranslation("UCSB Skydiving Club")
+            .inactive(false)
+            .build();
+
+    ArrayList<UCSBOrganization> expectedOrgs = new ArrayList<>();
+    expectedOrgs.addAll(Arrays.asList(zpr, sky));
+
+    when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrgs);
+
+    MvcResult response =
+        mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().isOk()).andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedOrgs);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_organization() throws Exception {
+    UCSBOrganization zpr =
+        UCSBOrganization.builder()
+            .orgCode("ZPR")
+            .orgTranslationShort("Zeta Phi Rho")
+            .orgTranslation("Zeta Phi Rho Fraternity")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.save(eq(zpr))).thenReturn(zpr);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/UCSBOrganization/post")
+                    .param("orgCode", "ZPR")
+                    .param("orgTranslationShort", "Zeta Phi Rho")
+                    .param("orgTranslation", "Zeta Phi Rho Fraternity")
+                    .param("inactive", "false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).save(zpr);
+    String expectedJson = mapper.writeValueAsString(zpr);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_inactive_organization() throws Exception {
+    UCSBOrganization osli =
+        UCSBOrganization.builder()
+            .orgCode("OSLI")
+            .orgTranslationShort("Student Life")
+            .orgTranslation("Office of Student Life")
+            .inactive(true)
+            .build();
+
+    when(ucsbOrganizationRepository.save(eq(osli))).thenReturn(osli);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/UCSBOrganization/post")
+                    .param("orgCode", "OSLI")
+                    .param("orgTranslationShort", "Student Life")
+                    .param("orgTranslation", "Office of Student Life")
+                    .param("inactive", "true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(ucsbOrganizationRepository, times(1)).save(osli);
+    String expectedJson = mapper.writeValueAsString(osli);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
## Add UCSBOrganizationController with GET and POST endpoints

Closes #15

### Description
This PR adds `UCSBOrganizationController.java` with the following endpoints:

- `GET /api/UCSBOrganization/all` — returns a list of all organizations in the database
- `POST /api/UCSBOrganization/post` — creates a new organization (admin only)

### Testing
- All tests pass
- Jacoco line/branch coverage: 100%
- Pitest mutation test strength: 100%
- Endpoints verified working on localhost via Swagger UI
- Endpoints verified working on Dokku deployment