### PR TITLE
Add GET ALL and POST Endpts for RecommendationRequests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
@@ -1,0 +1,170 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for RecommendationRequests */
+@Tag(name = "RecommendationRequests")
+@RequestMapping("/api/recommendationrequests")
+@RestController
+@Slf4j
+public class RecommendationRequestsController extends ApiController {
+
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+
+  /**
+   * List all recommendation requests
+   *
+   * @return an iterable of RecommendationRequest
+   */
+  @Operation(summary = "List all recommendation requests")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<RecommendationRequest> allRecommendationRequests() {
+    Iterable<RecommendationRequest> recommendationRequests =
+        recommendationRequestRepository.findAll();
+    return recommendationRequests;
+  }
+
+  /**
+   * Get a single recommendation request by id
+   *
+   * @param id the id of the recommendation request
+   * @return a RecommendationRequest
+   */
+  @Operation(summary = "Get a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    return recommendationRequest;
+  }
+
+  /**
+   * Create a new recommendation request
+   *
+   * @param requesterEmail the requester's email address
+   * @param professorEmail the professor's email address
+   * @param explanation explanation for recommendation request
+   * @param dateRequested date the recommendation request was made
+   * @param dateNeeded date the recommendation is needed by
+   * @param done whether the recommendation request has been completed
+   * @return the saved recommendation request
+   */
+  @Operation(summary = "Create a new recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public RecommendationRequest postRecommendationRequest(
+      @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+      @Parameter(name = "professorEmail") @RequestParam String professorEmail,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(
+              name = "dateRequested",
+              description =
+                  "date requested (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateRequested")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateRequested,
+      @Parameter(
+              name = "dateNeeded",
+              description =
+                  "date needed (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateNeeded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateNeeded,
+      @Parameter(name = "done") @RequestParam Boolean done)
+      throws JsonProcessingException {
+
+    // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    // See: https://www.baeldung.com/spring-date-parameters
+
+    log.info("dateRequested={}", dateRequested);
+    log.info("dateNeeded={}", dateNeeded);
+
+    RecommendationRequest recommendationRequest = new RecommendationRequest();
+    recommendationRequest.setRequesterEmail(requesterEmail);
+    recommendationRequest.setProfessorEmail(professorEmail);
+    recommendationRequest.setExplanation(explanation);
+    recommendationRequest.setDateRequested(dateRequested);
+    recommendationRequest.setDateNeeded(dateNeeded);
+    recommendationRequest.setDone(done);
+
+    RecommendationRequest savedRecommendationRequest =
+        recommendationRequestRepository.save(recommendationRequest);
+
+    return savedRecommendationRequest;
+  }
+
+  /**
+   * Delete a RecommendationRequest
+   *
+   * @param id the id of the recommendation request to delete
+   * @return a message indicating the recommendation request was deleted
+   */
+  @Operation(summary = "Delete a RecommendationRequest")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id) {
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    recommendationRequestRepository.delete(recommendationRequest);
+    return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+  }
+
+  /**
+   * Update a single recommendation request
+   *
+   * @param id id of the recommendation request to update
+   * @param incoming the new recommendation request
+   * @return the updated recommendation request object
+   */
+  @Operation(summary = "Update a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public RecommendationRequest updateRecommendationRequest(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid RecommendationRequest incoming) {
+
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+    recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+    recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+    recommendationRequest.setExplanation(incoming.getExplanation());
+    recommendationRequest.setDateRequested(incoming.getDateRequested());
+    recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+    recommendationRequest.setDone(incoming.getDone());
+
+    recommendationRequestRepository.save(recommendationRequest);
+
+    return recommendationRequest;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
@@ -2,22 +2,17 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.RecommendationRequest;
-import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,23 +40,23 @@ public class RecommendationRequestsController extends ApiController {
     return recommendationRequests;
   }
 
-  /**
-   * Get a single recommendation request by id
-   *
-   * @param id the id of the recommendation request
-   * @return a RecommendationRequest
-   */
-  @Operation(summary = "Get a single recommendation request")
-  @PreAuthorize("hasRole('ROLE_USER')")
-  @GetMapping("")
-  public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
-    RecommendationRequest recommendationRequest =
-        recommendationRequestRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+  // /**
+  //  * Get a single recommendation request by id
+  //  *
+  //  * @param id the id of the recommendation request
+  //  * @return a RecommendationRequest
+  //  */
+  // @Operation(summary = "Get a single recommendation request")
+  // @PreAuthorize("hasRole('ROLE_USER')")
+  // @GetMapping("")
+  // public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+  //   RecommendationRequest recommendationRequest =
+  //       recommendationRequestRepository
+  //           .findById(id)
+  //           .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
-    return recommendationRequest;
-  }
+  //   return recommendationRequest;
+  // }
 
   /**
    * Create a new recommendation request
@@ -118,53 +113,53 @@ public class RecommendationRequestsController extends ApiController {
     return savedRecommendationRequest;
   }
 
-  /**
-   * Delete a RecommendationRequest
-   *
-   * @param id the id of the recommendation request to delete
-   * @return a message indicating the recommendation request was deleted
-   */
-  @Operation(summary = "Delete a RecommendationRequest")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @DeleteMapping("")
-  public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id) {
-    RecommendationRequest recommendationRequest =
-        recommendationRequestRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+  // /**
+  //  * Delete a RecommendationRequest
+  //  *
+  //  * @param id the id of the recommendation request to delete
+  //  * @return a message indicating the recommendation request was deleted
+  //  */
+  // @Operation(summary = "Delete a RecommendationRequest")
+  // @PreAuthorize("hasRole('ROLE_ADMIN')")
+  // @DeleteMapping("")
+  // public Object deleteRecommendationRequest(@Parameter(name = "id") @RequestParam Long id) {
+  //   RecommendationRequest recommendationRequest =
+  //       recommendationRequestRepository
+  //           .findById(id)
+  //           .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
-    recommendationRequestRepository.delete(recommendationRequest);
-    return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
-  }
+  //   recommendationRequestRepository.delete(recommendationRequest);
+  //   return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+  // }
 
-  /**
-   * Update a single recommendation request
-   *
-   * @param id id of the recommendation request to update
-   * @param incoming the new recommendation request
-   * @return the updated recommendation request object
-   */
-  @Operation(summary = "Update a single recommendation request")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @PutMapping("")
-  public RecommendationRequest updateRecommendationRequest(
-      @Parameter(name = "id") @RequestParam Long id,
-      @RequestBody @Valid RecommendationRequest incoming) {
+  // /**
+  //  * Update a single recommendation request
+  //  *
+  //  * @param id id of the recommendation request to update
+  //  * @param incoming the new recommendation request
+  //  * @return the updated recommendation request object
+  //  */
+  // @Operation(summary = "Update a single recommendation request")
+  // @PreAuthorize("hasRole('ROLE_ADMIN')")
+  // @PutMapping("")
+  // public RecommendationRequest updateRecommendationRequest(
+  //     @Parameter(name = "id") @RequestParam Long id,
+  //     @RequestBody @Valid RecommendationRequest incoming) {
 
-    RecommendationRequest recommendationRequest =
-        recommendationRequestRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+  //   RecommendationRequest recommendationRequest =
+  //       recommendationRequestRepository
+  //           .findById(id)
+  //           .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
-    recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
-    recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
-    recommendationRequest.setExplanation(incoming.getExplanation());
-    recommendationRequest.setDateRequested(incoming.getDateRequested());
-    recommendationRequest.setDateNeeded(incoming.getDateNeeded());
-    recommendationRequest.setDone(incoming.getDone());
+  //   recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+  //   recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+  //   recommendationRequest.setExplanation(incoming.getExplanation());
+  //   recommendationRequest.setDateRequested(incoming.getDateRequested());
+  //   recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+  //   recommendationRequest.setDone(incoming.getDone());
 
-    recommendationRequestRepository.save(recommendationRequest);
+  //   recommendationRequestRepository.save(recommendationRequest);
 
-    return recommendationRequest;
-  }
+  //   return recommendationRequest;
+  // }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
@@ -1,0 +1,381 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = RecommendationRequestsController.class)
+@Import(TestConfig.class)
+public class RecommendationRequestsControllerTests extends ControllerTestCase {
+
+  @MockitoBean RecommendationRequestRepository recommendationRequestRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/recommendationrequests/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/recommendationrequests/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200)); // logged
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/recommendationrequests").param("id", "7"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
+
+  // Authorization tests for /api/recommendationrequests/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "bbob@ucsb.edu")
+                .param("professorEmail", "ppop@ucsb.edu")
+                .param("explanation", "Please.")
+                .param("dateRequested", "2022-01-03T00:00:00")
+                .param("dateNeeded", "2023-01-03T00:00:01")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/recommendationrequests/post")
+                .param("requesterEmail", "bbob@ucsb.edu")
+                .param("professorEmail", "ppop@ucsb.edu")
+                .param("explanation", "Please.")
+                .param("dateRequested", "2022-01-03T00:00:00")
+                .param("dateNeeded", "2023-01-03T00:00:01")
+                .param("done", "false")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  // // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    RecommendationRequest recommendationRequest =
+        RecommendationRequest.builder()
+            .requesterEmail("bbob@ucsb.edu")
+            .professorEmail("ppop@ucsb.edu")
+            .explanation("Please.")
+            .dateRequested(ldt)
+            .dateNeeded(ldt)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.findById(eq(7L)))
+        .thenReturn(Optional.of(recommendationRequest));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(recommendationRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    RecommendationRequest recommendationRequest1 =
+        RecommendationRequest.builder()
+            .requesterEmail("bbob@ucsb.edu")
+            .professorEmail("ppop@ucsb.edu")
+            .explanation("Please.")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt1)
+            .done(false)
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+    RecommendationRequest recommendationRequest2 =
+        RecommendationRequest.builder()
+            .requesterEmail("jjoj@ucsb.edu")
+            .professorEmail("yyoy@ucsb.edu")
+            .explanation("Thanks in advance.")
+            .dateRequested(ldt2)
+            .dateNeeded(ldt2)
+            .done(true)
+            .build();
+
+    ArrayList<RecommendationRequest> expectedRequests = new ArrayList<>();
+    expectedRequests.addAll(Arrays.asList(recommendationRequest1, recommendationRequest2));
+
+    when(recommendationRequestRepository.findAll()).thenReturn(expectedRequests);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(recommendationRequestRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedRequests);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    RecommendationRequest recommendationRequest1 =
+        RecommendationRequest.builder()
+            .requesterEmail("bbob@ucsb.edu")
+            .professorEmail("ppop@ucsb.edu")
+            .explanation("Please.")
+            .dateRequested(ldt1)
+            .dateNeeded(ldt1)
+            .done(false)
+            .build();
+
+    when(recommendationRequestRepository.save(eq(recommendationRequest1)))
+        .thenReturn(recommendationRequest1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/recommendationrequests/post")
+                    .param("requesterEmail", "bbob@ucsb.edu")
+                    .param("professorEmail", "ppop@ucsb.edu")
+                    .param("explanation", "Please.")
+                    .param("dateRequested", "2022-01-03T00:00:00")
+                    .param("dateNeeded", "2022-01-03T00:00:00")
+                    .param("done", "false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(recommendationRequestRepository, times(1)).save(recommendationRequest1);
+    String expectedJson = mapper.writeValueAsString(recommendationRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  //   @WithMockUser(roles = {"ADMIN", "USER"})
+  //   @Test
+  //   public void admin_can_delete_a_date() throws Exception {
+  //     // arrange
+
+  //     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+  //     RecommendationRequest recommendationRequest1 =
+  //         RecommendationRequest.builder()
+  //             .name("firstDayOfClasses")
+  //             .quarterYYYYQ("20222")
+  //             .localDateTime(ldt1)
+  //             .build();
+
+  //
+  // when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(recommendationRequest1));
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(delete("/api/recommendationrequests").param("id", "15").with(csrf()))
+  //             .andExpect(status().isOk())
+  //             .andReturn();
+
+  //     // assert
+  //     verify(recommendationRequestRepository, times(1)).findById(15L);
+  //     verify(recommendationRequestRepository, times(1)).delete(any());
+
+  //     Map<String, Object> json = responseToJson(response);
+  //     assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+  //   }
+
+  //   @WithMockUser(roles = {"ADMIN", "USER"})
+  //   @Test
+  //   public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+  //       throws Exception {
+  //     // arrange
+
+  //     when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(delete("/api/recommendationrequests").param("id", "15").with(csrf()))
+  //             .andExpect(status().isNotFound())
+  //             .andReturn();
+
+  //     // assert
+  //     verify(recommendationRequestRepository, times(1)).findById(15L);
+  //     Map<String, Object> json = responseToJson(response);
+  //     assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+  //   }
+
+  //   @WithMockUser(roles = {"ADMIN", "USER"})
+  //   @Test
+  //   public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+  //     // arrange
+
+  //     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+  //     LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+  //     RecommendationRequest ucsbDateOrig =
+  //         RecommendationRequest.builder()
+  //             .name("firstDayOfClasses")
+  //             .quarterYYYYQ("20222")
+  //             .localDateTime(ldt1)
+  //             .build();
+
+  //     RecommendationRequest ucsbDateEdited =
+  //         RecommendationRequest.builder()
+  //             .name("firstDayOfFestivus")
+  //             .quarterYYYYQ("20232")
+  //             .localDateTime(ldt2)
+  //             .build();
+
+  //     String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+  //
+  // when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(
+  //                 put("/api/recommendationrequests")
+  //                     .param("id", "67")
+  //                     .contentType(MediaType.APPLICATION_JSON)
+  //                     .characterEncoding("utf-8")
+  //                     .content(requestBody)
+  //                     .with(csrf()))
+  //             .andExpect(status().isOk())
+  //             .andReturn();
+
+  //     // assert
+  //     verify(recommendationRequestRepository, times(1)).findById(67L);
+  //     verify(recommendationRequestRepository, times(1)).save(ucsbDateEdited); // should be saved
+  // with correct user
+  //     String responseString = response.getResponse().getContentAsString();
+  //     assertEquals(requestBody, responseString);
+  //   }
+
+  //   @WithMockUser(roles = {"ADMIN", "USER"})
+  //   @Test
+  //   public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+  //     // arrange
+
+  //     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+  //     RecommendationRequest ucsbEditedDate =
+  //         RecommendationRequest.builder()
+  //             .name("firstDayOfClasses")
+  //             .quarterYYYYQ("20222")
+  //             .localDateTime(ldt1)
+  //             .build();
+
+  //     String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+  //     when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(
+  //                 put("/api/recommendationrequests")
+  //                     .param("id", "67")
+  //                     .contentType(MediaType.APPLICATION_JSON)
+  //                     .characterEncoding("utf-8")
+  //                     .content(requestBody)
+  //                     .with(csrf()))
+  //             .andExpect(status().isNotFound())
+  //             .andReturn();
+
+  //     // assert
+  //     verify(recommendationRequestRepository, times(1)).findById(67L);
+  //     Map<String, Object> json = responseToJson(response);
+  //     assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
+  //   }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
@@ -17,8 +17,6 @@ import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -49,12 +47,12 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
     mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200)); // logged
   }
 
-  @Test
-  public void logged_out_users_cannot_get_by_id() throws Exception {
-    mockMvc
-        .perform(get("/api/recommendationrequests").param("id", "7"))
-        .andExpect(status().is(403)); // logged out users can't get by id
-  }
+  //   @Test
+  //   public void logged_out_users_cannot_get_by_id() throws Exception {
+  //     mockMvc
+  //         .perform(get("/api/recommendationrequests").param("id", "7"))
+  //         .andExpect(status().is(403)); // logged out users can't get by id
+  //   }
 
   // Authorization tests for /api/recommendationrequests/post
   // (Perhaps should also have these for put and delete)
@@ -92,67 +90,68 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   // // Tests with mocks for database actions
 
+  //   @WithMockUser(roles = {"USER"})
+  //   @Test
+  //   public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+  //     // arrange
+  //     LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+  //     RecommendationRequest recommendationRequest =
+  //         RecommendationRequest.builder()
+  //             .requesterEmail("bbob@ucsb.edu")
+  //             .professorEmail("ppop@ucsb.edu")
+  //             .explanation("Please.")
+  //             .dateRequested(ldt)
+  //             .dateNeeded(ldt)
+  //             .done(false)
+  //             .build();
+
+  //     when(recommendationRequestRepository.findById(eq(7L)))
+  //         .thenReturn(Optional.of(recommendationRequest));
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(get("/api/recommendationrequests").param("id", "7"))
+  //             .andExpect(status().isOk())
+  //             .andReturn();
+
+  //     // assert
+
+  //     verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+  //     String expectedJson = mapper.writeValueAsString(recommendationRequest);
+  //     String responseString = response.getResponse().getContentAsString();
+  //     assertEquals(expectedJson, responseString);
+  //   }
+
+  //   @WithMockUser(roles = {"USER"})
+  //   @Test
+  //   public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws
+  // Exception {
+
+  //     // arrange
+
+  //     when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+  //     // act
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(get("/api/recommendationrequests").param("id", "7"))
+  //             .andExpect(status().isNotFound())
+  //             .andReturn();
+
+  //     // assert
+
+  //     verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+  //     Map<String, Object> json = responseToJson(response);
+  //     assertEquals("EntityNotFoundException", json.get("type"));
+  //     assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+  //   }
+
   @WithMockUser(roles = {"USER"})
   @Test
-  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
-
-    // arrange
-    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
-
-    RecommendationRequest recommendationRequest =
-        RecommendationRequest.builder()
-            .requesterEmail("bbob@ucsb.edu")
-            .professorEmail("ppop@ucsb.edu")
-            .explanation("Please.")
-            .dateRequested(ldt)
-            .dateNeeded(ldt)
-            .done(false)
-            .build();
-
-    when(recommendationRequestRepository.findById(eq(7L)))
-        .thenReturn(Optional.of(recommendationRequest));
-
-    // act
-    MvcResult response =
-        mockMvc
-            .perform(get("/api/recommendationrequests").param("id", "7"))
-            .andExpect(status().isOk())
-            .andReturn();
-
-    // assert
-
-    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
-    String expectedJson = mapper.writeValueAsString(recommendationRequest);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-  }
-
-  @WithMockUser(roles = {"USER"})
-  @Test
-  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
-
-    // arrange
-
-    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
-
-    // act
-    MvcResult response =
-        mockMvc
-            .perform(get("/api/recommendationrequests").param("id", "7"))
-            .andExpect(status().isNotFound())
-            .andReturn();
-
-    // assert
-
-    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
-  }
-
-  @WithMockUser(roles = {"USER"})
-  @Test
-  public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+  public void logged_in_user_can_get_all_recommendationrequests() throws Exception {
 
     // arrange
     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -201,7 +200,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
-  public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+  public void an_admin_user_can_post_a_new_recommendationrequest() throws Exception {
     // arrange
 
     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -239,6 +238,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(recommendationRequest1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+    assertEquals(recommendationRequest1.getDone(), false); // for the mutation test
   }
 
   //   @WithMockUser(roles = {"ADMIN", "USER"})
@@ -275,7 +275,8 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   //   @WithMockUser(roles = {"ADMIN", "USER"})
   //   @Test
-  //   public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+  //   public void
+  // admin_tries_to_delete_non_existant_recommendationrequest_and_gets_right_error_message()
   //       throws Exception {
   //     // arrange
 
@@ -296,30 +297,30 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   //   @WithMockUser(roles = {"ADMIN", "USER"})
   //   @Test
-  //   public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+  //   public void admin_can_edit_an_existing_recommendationrequest() throws Exception {
   //     // arrange
 
   //     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
   //     LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
 
-  //     RecommendationRequest ucsbDateOrig =
+  //     RecommendationRequest recommendationRequestOrig =
   //         RecommendationRequest.builder()
   //             .name("firstDayOfClasses")
   //             .quarterYYYYQ("20222")
   //             .localDateTime(ldt1)
   //             .build();
 
-  //     RecommendationRequest ucsbDateEdited =
+  //     RecommendationRequest recommendationRequestEdited =
   //         RecommendationRequest.builder()
   //             .name("firstDayOfFestivus")
   //             .quarterYYYYQ("20232")
   //             .localDateTime(ldt2)
   //             .build();
 
-  //     String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+  //     String requestBody = mapper.writeValueAsString(recommendationRequestEdited);
 
   //
-  // when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+  // when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(recommendationRequestOrig));
 
   //     // act
   //     MvcResult response =
@@ -336,7 +337,8 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   //     // assert
   //     verify(recommendationRequestRepository, times(1)).findById(67L);
-  //     verify(recommendationRequestRepository, times(1)).save(ucsbDateEdited); // should be saved
+  //     verify(recommendationRequestRepository, times(1)).save(recommendationRequestEdited); //
+  // should be saved
   // with correct user
   //     String responseString = response.getResponse().getContentAsString();
   //     assertEquals(requestBody, responseString);
@@ -344,7 +346,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
 
   //   @WithMockUser(roles = {"ADMIN", "USER"})
   //   @Test
-  //   public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+  //   public void admin_cannot_edit_recommendationrequest_that_does_not_exist() throws Exception {
   //     // arrange
 
   //     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -212,7 +213,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
             .explanation("Please.")
             .dateRequested(ldt1)
             .dateNeeded(ldt1)
-            .done(false)
+            .done(true)
             .build();
 
     when(recommendationRequestRepository.save(eq(recommendationRequest1)))
@@ -228,7 +229,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
                     .param("explanation", "Please.")
                     .param("dateRequested", "2022-01-03T00:00:00")
                     .param("dateNeeded", "2022-01-03T00:00:00")
-                    .param("done", "false")
+                    .param("done", "true")
                     .with(csrf()))
             .andExpect(status().isOk())
             .andReturn();
@@ -238,7 +239,7 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(recommendationRequest1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
-    assertEquals(recommendationRequest1.getDone(), false); // for the mutation test
+    assertTrue(responseString.contains(":true")); // for the mutation test
   }
 
   //   @WithMockUser(roles = {"ADMIN", "USER"})


### PR DESCRIPTION
Closes #21 

Implemented Get all and Post endpts according to UCSBDates examples for controller/controller test files. Jacoco test coverage shown below (red = next issues). GitHub Actions currently says Jacoco fails due to [files irrelevant to this issue](https://ucsb-cs156-s26.slack.com/archives/C0APWSJ513M/p1777097942001559).

<img width="1370" height="575" alt="image" src="https://github.com/user-attachments/assets/3993aa8f-2101-4221-959a-bbed739a90b5" />

Edit: mutation coverage has been fixed. Now 100%
<img width="1513" height="579" alt="image" src="https://github.com/user-attachments/assets/0689c843-7668-42cd-bd3d-3e69febe2d68" />

GET ALL and POST work on dokku:
<img width="556" height="613" alt="image" src="https://github.com/user-attachments/assets/0b8ea0df-722f-43b0-89e4-69e63efca4bb" />
