### PR TITLE
Add GET Endpt for RecommendationRequests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.example.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,23 +41,23 @@ public class RecommendationRequestsController extends ApiController {
     return recommendationRequests;
   }
 
-  // /**
-  //  * Get a single recommendation request by id
-  //  *
-  //  * @param id the id of the recommendation request
-  //  * @return a RecommendationRequest
-  //  */
-  // @Operation(summary = "Get a single recommendation request")
-  // @PreAuthorize("hasRole('ROLE_USER')")
-  // @GetMapping("")
-  // public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
-  //   RecommendationRequest recommendationRequest =
-  //       recommendationRequestRepository
-  //           .findById(id)
-  //           .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+  /**
+   * Get a single recommendation request by id
+   *
+   * @param id the id of the recommendation request
+   * @return a RecommendationRequest
+   */
+  @Operation(summary = "Get a single recommendation request")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public RecommendationRequest getById(@Parameter(name = "id") @RequestParam Long id) {
+    RecommendationRequest recommendationRequest =
+        recommendationRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
 
-  //   return recommendationRequest;
-  // }
+    return recommendationRequest;
+  }
 
   /**
    * Create a new recommendation request

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestsControllerTests.java
@@ -18,6 +18,8 @@ import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -48,12 +50,12 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
     mockMvc.perform(get("/api/recommendationrequests/all")).andExpect(status().is(200)); // logged
   }
 
-  //   @Test
-  //   public void logged_out_users_cannot_get_by_id() throws Exception {
-  //     mockMvc
-  //         .perform(get("/api/recommendationrequests").param("id", "7"))
-  //         .andExpect(status().is(403)); // logged out users can't get by id
-  //   }
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/recommendationrequests").param("id", "7"))
+        .andExpect(status().is(403)); // logged out users can't get by id
+  }
 
   // Authorization tests for /api/recommendationrequests/post
   // (Perhaps should also have these for put and delete)
@@ -89,66 +91,65 @@ public class RecommendationRequestsControllerTests extends ControllerTestCase {
         .andExpect(status().is(403)); // only admins can post
   }
 
-  // // Tests with mocks for database actions
+  // Tests with mocks for database actions
 
-  //   @WithMockUser(roles = {"USER"})
-  //   @Test
-  //   public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
 
-  //     // arrange
-  //     LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
 
-  //     RecommendationRequest recommendationRequest =
-  //         RecommendationRequest.builder()
-  //             .requesterEmail("bbob@ucsb.edu")
-  //             .professorEmail("ppop@ucsb.edu")
-  //             .explanation("Please.")
-  //             .dateRequested(ldt)
-  //             .dateNeeded(ldt)
-  //             .done(false)
-  //             .build();
+    RecommendationRequest recommendationRequest =
+        RecommendationRequest.builder()
+            .requesterEmail("bbob@ucsb.edu")
+            .professorEmail("ppop@ucsb.edu")
+            .explanation("Please.")
+            .dateRequested(ldt)
+            .dateNeeded(ldt)
+            .done(false)
+            .build();
 
-  //     when(recommendationRequestRepository.findById(eq(7L)))
-  //         .thenReturn(Optional.of(recommendationRequest));
+    when(recommendationRequestRepository.findById(eq(7L)))
+        .thenReturn(Optional.of(recommendationRequest));
 
-  //     // act
-  //     MvcResult response =
-  //         mockMvc
-  //             .perform(get("/api/recommendationrequests").param("id", "7"))
-  //             .andExpect(status().isOk())
-  //             .andReturn();
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
 
-  //     // assert
+    // assert
 
-  //     verify(recommendationRequestRepository, times(1)).findById(eq(7L));
-  //     String expectedJson = mapper.writeValueAsString(recommendationRequest);
-  //     String responseString = response.getResponse().getContentAsString();
-  //     assertEquals(expectedJson, responseString);
-  //   }
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(recommendationRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
 
-  //   @WithMockUser(roles = {"USER"})
-  //   @Test
-  //   public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws
-  // Exception {
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
 
-  //     // arrange
+    // arrange
 
-  //     when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+    when(recommendationRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
-  //     // act
-  //     MvcResult response =
-  //         mockMvc
-  //             .perform(get("/api/recommendationrequests").param("id", "7"))
-  //             .andExpect(status().isNotFound())
-  //             .andReturn();
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequests").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
 
-  //     // assert
+    // assert
 
-  //     verify(recommendationRequestRepository, times(1)).findById(eq(7L));
-  //     Map<String, Object> json = responseToJson(response);
-  //     assertEquals("EntityNotFoundException", json.get("type"));
-  //     assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
-  //   }
+    verify(recommendationRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("RecommendationRequest with id 7 not found", json.get("message"));
+  }
 
   @WithMockUser(roles = {"USER"})
   @Test


### PR DESCRIPTION
Closes #22 

[Note: failed jacoco GH Action is irrelevant to this issue.](https://ucsb-cs156-s26.slack.com/archives/C0APWSJ513M/p1777097942001559)

Swagger endpt functions as expected on localhost and dokku:
<img width="844" height="513" alt="image" src="https://github.com/user-attachments/assets/99e3c0c1-f7f0-44a3-8c4e-853d28b94a2e" />

Full test coverage with jacoco / pitest:
<img width="1116" height="321" alt="image" src="https://github.com/user-attachments/assets/18f3da60-41a2-4139-846e-cb56c69290f5" />
<img width="1694" height="213" alt="image" src="https://github.com/user-attachments/assets/2534fc5a-c09d-4f6d-9753-6761107d8215" />

