### PR TITLE
Add DELETE endpoint for MenuItemReview

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -98,6 +101,35 @@ public class MenuItemReviewController extends ApiController {
         menuItemReviewRepository
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return menuItemReview;
+  }
+
+  /**
+   * Update a single menu item review
+   *
+   * @param id id of the menu item review to update
+   * @param incoming the new menu item review
+   * @return the updated menu item review object
+   */
+  @Operation(summary = "Update a single menu item review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReview.setItemId(incoming.getItemId());
+    menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+    menuItemReview.setStars(incoming.getStars());
+    menuItemReview.setDateReviewed(incoming.getDateReviewed());
+    menuItemReview.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(menuItemReview);
 
     return menuItemReview;
   }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -103,6 +104,25 @@ public class MenuItemReviewController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
 
     return menuItemReview;
+  }
+
+  /**
+   * Delete a MenuItemReview
+   *
+   * @param id the id of the menu item review to delete
+   * @return a message indicating the menu item review was deleted
+   */
+  @Operation(summary = "Delete a MenuItemReview")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteMenuItemReview(@Parameter(name = "id") @RequestParam Long id) {
+    MenuItemReview menuItemReview =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    menuItemReviewRepository.delete(menuItemReview);
+    return genericMessage("MenuItemReview with id %s deleted".formatted(id));
   }
 
   /**

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -227,5 +228,94 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(mir1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+    MenuItemReview mirOrig =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(1)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    MenuItemReview mirEdited =
+        MenuItemReview.builder()
+            .itemId(2)
+            .reviewerEmail("b@a.com")
+            .stars(5)
+            .dateReviewed(ldt2)
+            .comments("greatest update ever")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(mirEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(mirOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    verify(menuItemReviewRepository, times(1)).save(mirEdited); // should be saved with correct user
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mirEdited =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(5)
+            .dateReviewed(ldt1)
+            .comments("greatest update ever II")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(mirEdited);
+
+    when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/menuitemreview")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(67L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 67 not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -228,6 +229,60 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(mir1);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_menuitemreview() throws Exception {
+    // arrange
+
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+    MenuItemReview mir1 =
+        MenuItemReview.builder()
+            .itemId(1)
+            .reviewerEmail("a@a.com")
+            .stars(1)
+            .dateReviewed(ldt1)
+            .comments("adsf")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(mir1));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+    verify(menuItemReviewRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+
+    when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/menuitemreview").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("MenuItemReview with id 15 not found", json.get("message"));
   }
 
   @WithMockUser(roles = {"ADMIN", "USER"})


### PR DESCRIPTION
Closes #30. Merge after PR #69 
Implement DELETE endpoint for MenuItemReview, which deletes a single MenuItemReview by id